### PR TITLE
fix: let VFS use file class structure for error handling

### DIFF
--- a/Ignis/src/Ignis.h
+++ b/Ignis/src/Ignis.h
@@ -1,4 +1,4 @@
-﻿#include "Ignis/Core/Application.h"
+#include "Ignis/Core/Application.h"
 #include "Ignis/Core/Input.h"
 #include "Ignis/Core/KeyCodes.h"
 #include "Ignis/Core/Log.h"
@@ -9,4 +9,5 @@
 #include "Ignis/Renderer/IndexBuffer.h"
 
 #include "Ignis/Core/FileSystem.h"
+#include "Ignis/Asset/File.h"
 #include "Ignis/Asset/VFS.h"

--- a/Ignis/src/Ignis/Asset/File.cpp
+++ b/Ignis/src/Ignis/Asset/File.cpp
@@ -1,0 +1,162 @@
+#include "File.h"
+#include "Ignis/Core/FileSystem.h"
+#include "Ignis/Core/Log.h"
+
+namespace ignis {
+
+    File::File(const std::filesystem::path& physical_path)
+        : m_path(physical_path)
+        , m_exists(false)
+        , m_is_open(false)
+        , m_is_readable(false)
+        , m_is_writable(false)
+        , m_size(0)
+    {
+        CheckFileState();
+    }
+
+    void File::CheckFileState()
+    {
+        // Check if file exists
+        m_exists = FileSystem::Exists(m_path);
+
+        if (!m_exists)
+        {
+            // File doesn't exist - check if we can create it (parent directory writable)
+            auto parent = m_path.parent_path();
+            if (parent.empty())
+                parent = std::filesystem::current_path();
+
+            if (!FileSystem::Exists(parent))
+            {
+                m_last_error = "Parent directory does not exist: " + parent.string();
+                m_is_open = false;
+                m_is_readable = false;
+                m_is_writable = false;
+                return;
+            }
+
+            // Try to create the file for writing
+            std::ofstream create_test(m_path);
+            m_is_writable = create_test.good();
+            create_test.close();
+
+            if (m_is_writable)
+            {
+                // File was created successfully, now it exists
+                m_exists = true;
+                m_is_readable = true;
+                m_is_open = true;
+                m_size = 0;
+                m_last_error.clear();
+                Log::CoreTrace("File: Created new file '{}' - Writable: true", m_path.string());
+            }
+            else
+            {
+                m_last_error = "Cannot create file (permission denied): " + m_path.string();
+                m_is_open = false;
+                m_is_readable = false;
+            }
+            return;
+        }
+
+        // File exists - check if it's a regular file
+        if (!FileSystem::IsFile(m_path))
+        {
+            m_last_error = "Path is not a regular file: " + m_path.string();
+            m_is_open = false;
+            m_is_readable = false;
+            m_is_writable = false;
+            return;
+        }
+
+        // Get file size
+        m_size = FileSystem::GetFileSize(m_path);
+
+        // Try to open for reading
+        std::ifstream read_test(m_path, std::ios::binary);
+        m_is_readable = read_test.good();
+        read_test.close();
+
+        // Try to open for writing (append mode to not destroy file)
+        std::ofstream write_test(m_path, std::ios::app);
+        m_is_writable = write_test.good();
+        write_test.close();
+
+        // File is considered "open" if it's at least readable
+        m_is_open = m_is_readable;
+
+        if (!m_is_open)
+        {
+            m_last_error = "Cannot open file (permission denied or file locked): " + m_path.string();
+        }
+        else
+        {
+            m_last_error.clear();
+        }
+
+        Log::CoreTrace("File: Checked state for '{}' - Open: {}, Readable: {}, Writable: {}", 
+            m_path.string(), m_is_open, m_is_readable, m_is_writable);
+    }
+
+    std::vector<uint8_t> File::ReadBinary()
+    {
+        if (!m_is_open || !m_is_readable)
+        {
+            Log::CoreError("File: Cannot read from unopened or unreadable file: {}", m_path.string());
+            return {};
+        }
+
+        return FileSystem::ReadBinaryFile(m_path);
+    }
+
+    std::string File::ReadText()
+    {
+        if (!m_is_open || !m_is_readable)
+        {
+            Log::CoreError("File: Cannot read from unopened or unreadable file: {}", m_path.string());
+            return "";
+        }
+
+        return FileSystem::ReadTextFile(m_path);
+    }
+
+    bool File::WriteBinary(const std::vector<uint8_t>& data)
+    {
+        if (!m_is_writable)
+        {
+            Log::CoreError("File: Cannot write to unwritable file: {}", m_path.string());
+            return false;
+        }
+
+        bool success = FileSystem::WriteBinaryFile(m_path, data);
+        
+        if (success)
+        {
+            // Update file state after writing
+            CheckFileState();
+        }
+
+        return success;
+    }
+
+    bool File::WriteText(const std::string& text)
+    {
+        if (!m_is_writable)
+        {
+            Log::CoreError("File: Cannot write to unwritable file: {}", m_path.string());
+            return false;
+        }
+
+        bool success = FileSystem::WriteTextFile(m_path, text);
+        
+        if (success)
+        {
+            // Update file state after writing
+            CheckFileState();
+        }
+
+        return success;
+    }
+
+}

--- a/Ignis/src/Ignis/Asset/File.h
+++ b/Ignis/src/Ignis/Asset/File.h
@@ -1,0 +1,41 @@
+#pragma once
+
+namespace ignis {
+
+    class File
+    {
+    public:
+        File(const std::filesystem::path& physical_path);
+
+        // State checking
+        bool IsOpen() const { return m_is_open; }
+        bool IsReadable() const { return m_is_readable; }
+        bool IsWritable() const { return m_is_writable; }
+        bool Exists() const { return m_exists; }
+
+        // File information
+        uint64_t GetSize() const { return m_size; }
+        const std::filesystem::path& GetPath() const { return m_path; }
+        const std::string& GetError() const { return m_last_error; }
+
+        // Read operations
+        std::vector<uint8_t> ReadBinary();
+        std::string ReadText();
+
+        // Write operations
+        bool WriteBinary(const std::vector<uint8_t>& data);
+        bool WriteText(const std::string& text);
+
+    private:
+        std::filesystem::path m_path;
+        bool m_exists;
+        bool m_is_open;
+        bool m_is_readable;
+        bool m_is_writable;
+        uint64_t m_size;
+        std::string m_last_error;
+
+        void CheckFileState();
+    };
+
+}

--- a/Ignis/src/Ignis/Asset/VFS.cpp
+++ b/Ignis/src/Ignis/Asset/VFS.cpp
@@ -135,52 +135,18 @@ namespace ignis {
         return FileSystem::Exists(physical_path);
     }
 
-    std::vector<uint8_t> VFS::ReadBinary(const std::string& virtual_path)
+    File VFS::Open(const std::string& virtual_path)
     {
         auto physical_path = Resolve(virtual_path);
         if (physical_path.empty())
         {
             Log::CoreError("VFS: Failed to resolve path: {}", virtual_path);
-            return {};
+            // Return a File object with an invalid path
+            return File("");
         }
 
-        return FileSystem::ReadBinaryFile(physical_path);
-    }
-
-    std::string VFS::ReadText(const std::string& virtual_path)
-    {
-        auto physical_path = Resolve(virtual_path);
-        if (physical_path.empty())
-        {
-            Log::CoreError("VFS: Failed to resolve path: {}", virtual_path);
-            return "";
-        }
-
-        return FileSystem::ReadTextFile(physical_path);
-    }
-
-    bool VFS::Write(const std::string& virtual_path, const std::vector<uint8_t>& data)
-    {
-        auto physical_path = Resolve(virtual_path);
-        if (physical_path.empty())
-        {
-            Log::CoreError("VFS: Failed to resolve path: {}", virtual_path);
-            return false;
-        }
-
-        return FileSystem::WriteBinaryFile(physical_path, data);
-    }
-
-    bool VFS::WriteText(const std::string& virtual_path, const std::string& text)
-    {
-        auto physical_path = Resolve(virtual_path);
-        if (physical_path.empty())
-        {
-            Log::CoreError("VFS: Failed to resolve path: {}", virtual_path);
-            return false;
-        }
-
-        return FileSystem::WriteTextFile(physical_path, text);
+        Log::CoreTrace("VFS: Opening file '{}'", virtual_path);
+        return File(physical_path);
     }
 
     std::vector<std::string> VFS::ListFiles(const std::string& virtual_directory, const std::string& filter)

--- a/Ignis/src/Ignis/Asset/VFS.h
+++ b/Ignis/src/Ignis/Asset/VFS.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "File.h"
+
 namespace ignis {
 
     class VFS
@@ -18,10 +20,7 @@ namespace ignis {
         static bool Exists(const std::string& virtual_path);
 
         // File operations through VFS
-        static std::vector<uint8_t> ReadBinary(const std::string& virtual_path);
-        static std::string ReadText(const std::string& virtual_path);
-        static bool Write(const std::string& virtual_path, const std::vector<uint8_t>& data);
-        static bool WriteText(const std::string& virtual_path, const std::string& text);
+        static File Open(const std::string& virtual_path);
 
         // Directory operations
         static std::vector<std::string> ListFiles(const std::string& virtual_directory, const std::string& filter = "*");

--- a/Ignis/src/Ignis/Core/Application.cpp
+++ b/Ignis/src/Ignis/Core/Application.cpp
@@ -26,29 +26,58 @@ namespace ignis
 		// VFS Test
 		Log::CoreInfo("\n=== VFS Test Start===");
 
-		// Test 1: Write a test file
+		// Test 1: Open file for writing
 		std::string test_data = "Hello from VFS!\nTest successful.";
-		if (VFS::WriteText("assets://vfs_test.txt", test_data))
+		auto write_file = VFS::Open("assets://vfs_test.txt");
+		if (write_file.IsOpen())
 		{
-			Log::CoreInfo("Write test passed");
+			Log::CoreInfo("File opened for writing");
 			
-			// Test 2: Read it back
-			std::string read_data = VFS::ReadText("assets://vfs_test.txt");
+			// Write test data
+			if (write_file.WriteText(test_data))
+			{
+				Log::CoreInfo("Write test passed");
+			}
+			else
+			{
+				Log::CoreError("Write test failed");
+			}
+		}
+		else
+		{
+			Log::CoreError("Cannot open file for writing: {}", write_file.GetError());
+		}
+		
+		// Test 2: Open file for reading
+		auto read_file = VFS::Open("assets://vfs_test.txt");
+		if (read_file.IsOpen())
+		{
+			Log::CoreInfo("File opened for reading - IsReadable: {}", read_file.IsReadable());
+			
+			std::string read_data = read_file.ReadText();
 			if (read_data == test_data)
 			{
 				Log::CoreInfo("Read test passed");
 			}
-			
-			// Test 3: Check file exists
-			if (VFS::Exists("assets://vfs_test.txt"))
+			else
 			{
-				Log::CoreInfo("Exists check passed");
+				Log::CoreError("Read test failed - data mismatch");
 			}
-			
-			// Test 4: List directory
-			auto files = VFS::ListFiles("assets://");
-			Log::CoreInfo("Found {} files in assets/", files.size());
 		}
+		else
+		{
+			Log::CoreError("Cannot open file for reading: {}", read_file.GetError());
+		}
+		
+		// Test 3: Check file exists
+		if (VFS::Exists("assets://vfs_test.txt"))
+		{
+			Log::CoreInfo("Exists check passed");
+		}
+		
+		// Test 4: List directory
+		auto files = VFS::ListFiles("assets://");
+		Log::CoreInfo("Found {} files in assets/", files.size());
 
 		// Test 5: Cleanup - Delete test file
 		auto test_file_path = VFS::Resolve("assets://vfs_test.txt");

--- a/Ignis/src/Ignis/Platform/OpenGL/GLShader.cpp
+++ b/Ignis/src/Ignis/Platform/OpenGL/GLShader.cpp
@@ -1,4 +1,5 @@
 #include "GLShader.h"
+#include "Ignis/Asset/VFS.h"
 #include <glad/glad.h>
 
 namespace ignis
@@ -141,16 +142,14 @@ namespace ignis
 
 	std::string ReadFileToString(const std::string& filepath)
 	{
-		std::ifstream file(filepath, std::ios::in | std::ios::binary);
-		if (!file.is_open())
+		auto file = VFS::Open(filepath);
+		if (!file.IsOpen())
 		{
-			Log::Error("ERROR::SHADER::IO::FAILED_TO_OPEN_FILE {0}", filepath);
+			Log::Error("ERROR::SHADER::IO::FAILED_TO_OPEN_FILE {0}: {1}", filepath, file.GetError());
 			return {};
 		}
 
-		std::ostringstream ss;
-		ss << file.rdbuf();
-		return ss.str();
+		return file.ReadText();
 	}
 
 	GLShader::GLShader(const std::string& vertex_source, const std::string& fragment_source)


### PR DESCRIPTION
## Description

Deleted: 
- VFS::ReadBinary(virtual_path)
- VFS::ReadText(virtual_path)
- VFS::Write(virtual_path, data)
- VFS::WriteText(virtual_path, text)

Added:
- New File class (Ignis/Asset/File.h, File.cpp)
- VFS::Open(virtual_path) - returns a File object
- File::IsOpen() 
- File::IsReadable() 
- File::IsWritable() 
- File::GetError() - get error message if file couldn't be opened
- File::GetSize()
- File::ReadBinary() / File::ReadText() - read from the file
- File::WriteBinary() / File::WriteText() - write to the file

## New library used

<!-- List any new libraries or dependencies added in this PR -->

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes

<!-- Add any additional notes, concerns, or context about this PR -->
