### PR TITLE
Fix: macOS _DEBUG macro not defined by default fix

### DIFF
--- a/Ignis/src/CMakeLists.txt
+++ b/Ignis/src/CMakeLists.txt
@@ -10,7 +10,9 @@ set_source_files_properties(
 
 add_library(Ignis SHARED ${IGNIS_SOURCES})
 add_library(Ignis::Ignis ALIAS Ignis)
-target_compile_definitions(Ignis PRIVATE IGNIS_BUILD_DLL)
+target_compile_definitions(Ignis PRIVATE IGNIS_BUILD_DLL
+    $<$<CONFIG:Debug>:_DEBUG>
+)
 
 if(MSVC)
     target_compile_options(Ignis PRIVATE /utf-8)

--- a/Ignis/src/Ignis/Project/Project.cpp
+++ b/Ignis/src/Ignis/Project/Project.cpp
@@ -39,10 +39,10 @@ namespace ignis
 
 	static std::string GetConfigTokenByMacro()
 	{
-	#if defined(NDEBUG)
-			return "Release";
-	#else
+	#if defined(_DEBUG)
 			return "Debug";
+	#else
+			return "Release";
 	#endif
 	}
 


### PR DESCRIPTION
## Description
- macOS _DEBUG macro not defined by default, so previously it looks for release script module instead of debug script module, which is wrong
<!-- Provide a brief summary of the changes made in this PR -->

## New library used

<!-- List any new libraries or dependencies added in this PR -->

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes

<!-- Add any additional notes, concerns, or context about this PR -->
