### PR TITLE
Feat: material slot UI improvement

### DIFF
--- a/Editor/src/Editor/Panels/PropertiesPanel.cpp
+++ b/Editor/src/Editor/Panels/PropertiesPanel.cpp
@@ -896,15 +896,78 @@ namespace ignis {
 				{
 					ImGui::PushID((int)i);
 					std::string header = "Material Slot " + std::to_string(i);
-					if (ImGui::TreeNodeEx(header.c_str(), ImGuiTreeNodeFlags_DefaultOpen))
+					if (ImGui::TreeNodeEx(header.c_str(), ImGuiTreeNodeFlags_None))
 					{
 						auto& slot = mesh_component.MaterialSlots[i];
+						
+						// Albedo
 						RenderTextureMapSlot("Albedo Map", slot.AlbedoMap, mesh_component, i, MaterialType::Albedo);
+						if (ImGui::ColorEdit4("Albedo Color", &slot.AlbedoColor.x))
+						{
+							if (mesh_component.Mesh.IsValid())
+							{
+								auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh);
+								if (mesh && i < mesh->GetMaterialsData().size())
+									mesh->SetMaterialData(i, slot);
+							}
+						}
+						ImGui::Separator();
+						
+						// Normal
 						RenderTextureMapSlot("Normal Map", slot.NormalMap, mesh_component, i, MaterialType::Normal);
+						ImGui::Separator();
+						
+						// Metalness
 						RenderTextureMapSlot("Metalness Map", slot.MetalnessMap, mesh_component, i, MaterialType::Metal);
+						if (ImGui::DragFloat("Metallic Value", &slot.MetallicValue, 0.01f, 0.0f, FLT_MAX))
+						{
+							if (mesh_component.Mesh.IsValid())
+							{
+								auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh);
+								if (mesh && i < mesh->GetMaterialsData().size())
+									mesh->SetMaterialData(i, slot);
+							}
+						}
+						ImGui::Separator();
+						
+						// Roughness
 						RenderTextureMapSlot("Roughness Map", slot.RoughnessMap, mesh_component, i, MaterialType::Roughness);
+						if (ImGui::DragFloat("Roughness Value", &slot.RoughnessValue, 0.01f, 0.0f, FLT_MAX))
+						{
+							if (mesh_component.Mesh.IsValid())
+							{
+								auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh);
+								if (mesh && i < mesh->GetMaterialsData().size())
+									mesh->SetMaterialData(i, slot);
+							}
+						}
+						ImGui::Separator();
+						
+						// Emissive
 						RenderTextureMapSlot("Emissive Map", slot.EmissiveMap, mesh_component, i, MaterialType::Emissive);
+						if (ImGui::ColorEdit3("Emissive Color", &slot.EmissiveColor.x))
+						{
+							if (mesh_component.Mesh.IsValid())
+							{
+								auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh);
+								if (mesh && i < mesh->GetMaterialsData().size())
+									mesh->SetMaterialData(i, slot);
+							}
+						}
+						if (ImGui::DragFloat("Emissive Intensity", &slot.EmissiveIntensity, 0.1f, 0.0f, FLT_MAX))
+						{
+							if (mesh_component.Mesh.IsValid())
+							{
+								auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh);
+								if (mesh && i < mesh->GetMaterialsData().size())
+									mesh->SetMaterialData(i, slot);
+							}
+						}
+						ImGui::Separator();
+						
+						// AO
 						RenderTextureMapSlot("AO Map", slot.AOMap, mesh_component, i, MaterialType::AO);
+						
 						ImGui::TreePop();
 					}
 					ImGui::PopID();


### PR DESCRIPTION
## Description

- Update material slots with new fields Albedo Color, Metallic Value, Roughness Value, Emissive Color, Emissive Intensity
- Let material slot not expand by default as models may have too many material slots -> too much space occupy in properties panel

<!-- Provide a brief summary of the changes made in this PR -->

## New library used

<!-- List any new libraries or dependencies added in this PR -->

## Type of change

<!-- Mark the relevant option with an [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes

<!-- Add any additional notes, concerns, or context about this PR -->
