### PR TITLE
fix: add TransformUVCoords when loading mesh

### DIFF
--- a/Ignis/src/Ignis/Asset/MeshImporter.cpp
+++ b/Ignis/src/Ignis/Asset/MeshImporter.cpp
@@ -233,7 +233,8 @@ namespace ignis
 			| aiProcess_CalcTangentSpace;
 
 		if (ext == ".gltf" || ext == ".glb")
-			flags |= aiProcess_PreTransformVertices;
+			flags |= aiProcess_PreTransformVertices
+			| aiProcess_TransformUVCoords;
 
 		const aiScene* scene = importer.ReadFile(model_path.string(), flags);
 


### PR DESCRIPTION
## Description

Added `aiProcess_TransformUVCoords` to Assimp post-processing flags in MeshImporter.

Some model formats (notably glTF with the `KHR_texture_transform` extension) store UV transformations (scale, rotation, offset) as material properties rather than baking them into vertex data. Without this flag, Assimp imports the raw vertex UVs as-is, leaving UV transforms unapplied. This caused textures to appear horizontally flipped on affected models, since the engine does not apply UV transforms at shader level.

`aiProcess_TransformUVCoords` resolves this by applying all material-level UV transformations directly into vertex UV coordinates during import, so no shader-side handling is needed.

## New library used

- None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes