### PR TITLE
fix: PopStyleVar before return

### DIFF
--- a/Editor/src/Editor/Panels/SceneHierarchyPanel.cpp
+++ b/Editor/src/Editor/Panels/SceneHierarchyPanel.cpp
@@ -347,6 +347,7 @@ namespace ignis {
 					ImGui::TreePop();
 				}
 				
+				ImGui::PopStyleVar();
 				return;
 			}
 			


### PR DESCRIPTION
## Description

Fixed a crash (`abort`) caused by a missing `ImGui::PopStyleVar()` call in `SceneHierarchyPanel::DrawEntityNode`. When deleting an entity via the right-click context menu, the function performed an early `return` without popping the `ImGuiStyleVar_ItemSpacing` that was pushed at the beginning of the function. This caused an ImGui assertion failure: `Missing PopStyleVar()`.

Added `ImGui::PopStyleVar()` before the early `return` in the delete entity code path to ensure the push/pop calls are balanced.

## New library used

- None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes