### PR TITLE
fix: render opaque mesh first

### DIFF
--- a/Ignis/src/Ignis/Platform/OpenGL/GLRenderer.cpp
+++ b/Ignis/src/Ignis/Platform/OpenGL/GLRenderer.cpp
@@ -225,11 +225,6 @@ namespace ignis
 			material->Set("model", model);
 			material->Set("viewPos", m_camera->GetPosition());
 
-			if (material_data.DoubleSided)
-				glDisable(GL_CULL_FACE);
-			else
-				glEnable(GL_CULL_FACE);
-
 			material->Bind();
 			glDrawElements(
 				GL_TRIANGLES,

--- a/Ignis/src/Ignis/Scene/Scene.cpp
+++ b/Ignis/src/Ignis/Scene/Scene.cpp
@@ -291,20 +291,56 @@ namespace ignis
 		{
 			auto meshes = m_registry.group<MeshComponent>(entt::get<TransformComponent>);
 
-			meshes.each([&](auto entity_handle, MeshComponent& mesh_component, TransformComponent& transform)
-				{
-					if (auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh))
-					{
-						const uint32_t slot_count = static_cast<uint32_t>(mesh_component.MaterialSlots.size());
-						for (uint32_t i = 0; i < slot_count; i++)
-						{
-							mesh->SetMaterialData(i, mesh_component.MaterialSlots[i]);
-						}
+			{
+				auto meshes = m_registry.group<MeshComponent>(entt::get<TransformComponent>);
 
-						Entity entity(entity_handle, this);
-						scene_renderer.SubmitMesh(*mesh, entity.GetWorldTransform());
-					}
-				});
+				struct MeshDrawCall
+				{
+					Mesh* MeshPtr;
+					glm::mat4 Transform;
+					bool IsBlend;
+				};
+				std::vector<MeshDrawCall> draw_calls;
+
+				meshes.each([&](auto entity_handle, MeshComponent& mesh_component, TransformComponent& transform)
+					{
+						if (auto mesh = AssetManager::GetAsset<Mesh>(mesh_component.Mesh))
+						{
+							const uint32_t slot_count = static_cast<uint32_t>(mesh_component.MaterialSlots.size());
+							for (uint32_t i = 0; i < slot_count; i++)
+							{
+								mesh->SetMaterialData(i, mesh_component.MaterialSlots[i]);
+							}
+
+							bool has_blend = false;
+							for (const auto& mat : mesh->GetMaterialsData())
+							{
+								if (mat.Alpha == AlphaMode::Blend)
+								{
+									has_blend = true;
+									break;
+								}
+							}
+
+							Entity entity(entity_handle, this);
+							draw_calls.push_back({ mesh.get(), entity.GetWorldTransform(), has_blend });
+						}
+					});
+
+				// Pass 1: Opaque / Mask
+				for (const auto& dc : draw_calls)
+				{
+					if (!dc.IsBlend)
+						scene_renderer.SubmitMesh(*dc.MeshPtr, dc.Transform);
+				}
+
+				// Pass 2: Blend
+				for (const auto& dc : draw_calls)
+				{
+					if (dc.IsBlend)
+						scene_renderer.SubmitMesh(*dc.MeshPtr, dc.Transform);
+				}
+			}
 		}
 
 		// -------------------------


### PR DESCRIPTION
## Description

Fixed transparent (AlphaMode::Blend) meshes disappearing when entering Play mode.

The root cause was that `Scene::OnRender` rendered all meshes in a single pass using the raw entt group iteration order. In the editor scene, this order happened to place opaque meshes before blend meshes, so everything appeared correct. However, when `CopyTo()` cloned the scene for runtime, the entt registry's internal pool ordering changed, causing blend meshes to render before opaque ones. Since blend rendering disables depth writes, the subsequently rendered opaque geometry would overwrite the blend pixels entirely, making all transparent meshes invisible.

The fix splits mesh rendering into two explicit passes: opaque/mask first, then blend. This guarantees correct draw order regardless of entt iteration order.

## New library used

- None

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes