### PR TITLE
fix: set ttf and otf as font ext

### DIFF
--- a/Ignis/src/Ignis/Asset/AssetManager.cpp
+++ b/Ignis/src/Ignis/Asset/AssetManager.cpp
@@ -182,6 +182,9 @@ namespace ignis
 			{ ".mp3",  AssetType::AudioClip },
 			{ ".flac", AssetType::AudioClip },
 			{ ".ogg",  AssetType::AudioClip },
+
+			{ ".ttf", AssetType::Font },
+			{ ".otf", AssetType::Font },
 		};
 
 		std::string extension = ToLowerASCII(path.extension().string());


### PR DESCRIPTION
## Description

Add `.ttf` and `.otf` to `DetermineTypeFromExtension`.

## New library used

- None

## Type of change

<!-- Mark the relevant option with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Additional notes

<!-- Add any additional notes, concerns, or context about this PR -->
